### PR TITLE
Patch 3.4.5 to clarify conda init language

### DIFF
--- a/recipe/clarify-conda-init.patch
+++ b/recipe/clarify-conda-init.patch
@@ -1,0 +1,55 @@
+diff --git a/constructor/header.sh b/constructor/header.sh
+index 7669ead..942ceee 100644
+--- a/constructor/header.sh
++++ b/constructor/header.sh
+@@ -544,8 +544,14 @@ if [ "$BATCH" = "0" ]; then
+ #if has_conda and initialize_conda is True
+     # Interactive mode.
+ 
+-    printf "Do you wish the installer to initialize %s\\n" "${INSTALLER_NAME}"
+-    printf "by running conda init? [yes|no]\\n"
++    printf "Do you wish to update your shell profile to automatically initialize conda?\\n"
++    printf "This will activate conda on startup and change the command prompt when activated.\\n"
++    printf "If you'd prefer that conda's base environment not be activated on startup,\\n"
++    printf "   run the following command when conda is activated:\\n"
++    printf "\\n"
++    printf "conda config --set auto_activate_base false\\n"
++    printf "\\n"
++    printf "You can undo this by running \`conda init --reverse \$SHELL\`? [yes|no]\\n"
+     printf "[%s] >>> " "$DEFAULT"
+     read -r ans
+     if [ "$ans" = "" ]; then
+@@ -578,11 +584,6 @@ if [ "$BATCH" = "0" ]; then
+             esac
+         fi
+     fi
+-    printf "If you'd prefer that conda's base environment not be activated on startup, \\n"
+-    printf "   set the auto_activate_base parameter to false: \\n"
+-    printf "\\n"
+-    printf "conda config --set auto_activate_base false\\n"
+-    printf "\\n"
+ #endif
+ 
+     printf "Thank you for installing %s!\\n" "${INSTALLER_NAME}"
+diff --git a/constructor/osxpkg.py b/constructor/osxpkg.py
+index 2628429..605067d 100644
+--- a/constructor/osxpkg.py
++++ b/constructor/osxpkg.py
+@@ -224,10 +224,13 @@ def modify_xml(xml_path, info):
+                 'initialize_by_default', True) else 'false')
+             path_choice.set('title', "Add conda initialization to the shell")
+             path_description = """
+-            If this box is checked, "conda init" will be executed to ensure that
+-            conda is available in your preferred shell upon startup. If unchecked,
+-            you must this initialization yourself or activate the environment
+-            manually for each shell in which you wish to use it."""
++            If this box is checked, conda will be automatically activated in your
++            preferred shell on startup. This will change the command prompt when
++            activated. If your prefer that conda's base environment not be activated
++            on startup, run `conda config --set auto_activate_base false`. You can
++            undo this by running `conda init --reverse ${SHELL}`.
++            If unchecked, you must this initialization yourself or activate the
++            environment manually for each shell in which you wish to use it."""
+             path_choice.set('description', ' '.join(path_description.split()))
+         elif ident.endswith('cacheclean'):
+             path_choice.set('visible', 'true')

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
       test-fixes.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - constructor = constructor.main:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,8 @@ source:
   - url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
     sha256: 8483b2b4a4d136ce7d750a3f0d6eb964d5e6295436fab74c7d855ca70f9b6c33
     patches:
-      test-fixes.patch
+      - test-fixes.patch
+      - clarify-conda-init.patch
 
 build:
   number: 1


### PR DESCRIPTION
A recent [upstream PR](https://github.com/conda/constructor/pull/713) in `constructor` requires a patch of the feedstock.

Changes in language around `conda init` has been a community request and should go into the new installer release. While we wait for a new release of `constructor`, keep this patched version of `3.4.5`

Jira: https://anaconda.atlassian.net/jira/software/projects/INST/issues/INST-274