### PR TITLE
Add compatibility warning for aarch64 RaspberryPi users

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,11 @@ package:
 source:
   - url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
     sha256: 787ffd85e9414bdf70fe531f01eab3987a040e3f6a6ac3a01409f4d332f7de9e
+    patches:                        # [aarch64]
+      - raspberry-pi-warning.patch  # [aarch64]
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - constructor = constructor.main:main
@@ -21,6 +23,7 @@ requirements:
     - pip
     - setuptools
     - wheel
+    - patch  # [aarch64]
   run:
     - conda >=4.6
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,12 +18,13 @@ build:
   skip: true  # [py<37]
 
 requirements:
+  build:
+    - patch  # [aarch64]
   host:
     - python
     - pip
     - setuptools
     - wheel
-    - patch  # [aarch64]
   run:
     - conda >=4.6
     - python

--- a/recipe/raspberry-pi-warning.patch
+++ b/recipe/raspberry-pi-warning.patch
@@ -1,0 +1,26 @@
+diff --git a/constructor/header.sh b/constructor/header.sh
+index 7669ead..bcaecc8 100644
+--- a/constructor/header.sh
++++ b/constructor/header.sh
+@@ -198,6 +198,21 @@ then
+ #endif
+ 
+ #if aarch64
++    if [[ -f /proc/device-tree/model && -n "$(cat /proc/device-tree/model | grep Raspberry)" ]]; then
++        printf "WARNING:\\n"
++        printf "    Your system appears to be a RaspberryPi.\\n"
++        printf "    Anaconda packages may not be compatible with this system.\\n"
++        printf "    Are sure you want to continue the installation? [yes|no]\\n"
++        printf "[no] >>> "
++        read -r ans
++        ans=$(echo "${ans}" | tr '[:lower:]' '[:upper:]')
++        if [ "$ans" != "YES" ] && [ "$ans" != "Y" ]
++        then
++            printf "Aborting installation\\n"
++            exit 2
++        fi
++    fi
++
+     if [ "$(uname -m)" != "aarch64" ]; then
+         printf "WARNING:\\n"
+         printf "    Your machine hardware does not appear to be aarch64, \\n"


### PR DESCRIPTION
Anaconda packages do not support RaspberryPi on `linux-aarch64` because they are optimized for Graviton.

This patch adds a warning to our installers that it may not be compatible with RaspberryPi