### PR TITLE
Pkg 4313 update 3.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.6.0" %}
+{% set version = "3.7.0" %}
 
 package:
   name: constructor
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
-    sha256: d47e6f805337de70a72dea62999853361fbf558e2fbf3a9016c7a007be82ff46
+    sha256: e84de1d7db3dbd394c03fa0e966bd293729307b9de0c8733ed7189f422a4b5b5
     patches:                        # [aarch64]
       - raspberry-pi-warning.patch  # [aarch64]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - constructor = constructor.main:main
-  skip: true  # [py<37]
+  skip: true  # [py<38]
 
 requirements:
   build:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4313](https://anaconda.atlassian.net/browse/PKG-4313) 
- [Upstream repository](https://github.com/conda/constructor/tree/3.7.0)
- [Upstream changelog/diff](https://github.com/conda/constructor/compare/3.6.0...3.7.0)

### Explanation of changes:

- Update version and SHA
- Drop python <3.8, as this is the new minimum upstream


[PKG-4313]: https://anaconda.atlassian.net/browse/PKG-4313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ