### PR TITLE
Update to v3.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.7.0" %}
+{% set version = "3.8.0" %}
 
 package:
   name: constructor
@@ -6,12 +6,12 @@ package:
 
 source:
   - url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
-    sha256: e84de1d7db3dbd394c03fa0e966bd293729307b9de0c8733ed7189f422a4b5b5
+    sha256: b10b675745e0d709d3e4a9106fba8e9169e6a940ab873a5ad02593dee9cf2fb4
     patches:                        # [aarch64]
       - raspberry-pi-warning.patch  # [aarch64]
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - constructor = constructor.main:main


### PR DESCRIPTION
constructor 3.8.0

**Destination channel:** defaults

### Links

- [PKG-4802](https://anaconda.atlassian.net/browse/PKG-4802) 
- [Upstream repository](https://github.com/conda/constructor)
- [Upstream changelog/diff](https://github.com/conda/constructor/blob/main/CHANGELOG.md#2024-05-13---380)

### Explanation of changes:

- Update to v3.8.0

[PKG-4802]: https://anaconda.atlassian.net/browse/PKG-4802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ