### PR TITLE
Update to v3.9.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
     - pip check
     # Image tests are failing because fonts are not available
     # Since we use our own images, this is not needed for now
-    - pytest -v tests -k "not examples" -k "not test_write_images"
+    - pytest -v tests -k "not examples and not test_write_images"
     # Long running integration tests
     # - python scripts/run_examples.py  # [not win]
     - constructor -V

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.8.0" %}
+{% set version = "3.9.0" %}
 
 package:
   name: constructor
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
-    sha256: b10b675745e0d709d3e4a9106fba8e9169e6a940ab873a5ad02593dee9cf2fb4
+    sha256: 5970b5b1dc661f786069010f62b191db8cd6be2d798c0451ce0fb6cfe56266d4
     patches:                        # [aarch64]
       - raspberry-pi-warning.patch  # [aarch64]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.9.0" %}
+{% set version = "3.9.2" %}
 
 package:
   name: constructor
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
-    sha256: 5970b5b1dc661f786069010f62b191db8cd6be2d798c0451ce0fb6cfe56266d4
+    sha256: 0ea4f6d563a53ebb03475dc6d2d88d3ab01be4e9d291fd276c79315aa92e5114
     patches:                        # [aarch64]
       - raspberry-pi-warning.patch  # [aarch64]
 
@@ -48,9 +48,7 @@ test:
     - conda-libmamba-solver
   commands:
     - pip check
-    # Image tests are failing because fonts are not available
-    # Since we use our own images, this is not needed for now
-    - pytest -v tests -k "not examples and not test_write_images"
+    - pytest -v tests -k "not examples"
     # Long running integration tests
     # - python scripts/run_examples.py  # [not win]
     - constructor -V

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,9 @@ requirements:
 test:
   source_files:
     - tests
-    - scripts
-    - examples
+    # Include when running examples
+    # - scripts
+    # - examples
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,9 @@ test:
     - conda-libmamba-solver
   commands:
     - pip check
-    - pytest -v tests -k "not examples"
+    # Image tests are failing because fonts are not available
+    # Since we use our own images, this is not needed for now
+    - pytest -v tests -k "not examples" -k "not test_write_images"
     # Long running integration tests
     # - python scripts/run_examples.py  # [not win]
     - constructor -V

--- a/recipe/raspberry-pi-warning.patch
+++ b/recipe/raspberry-pi-warning.patch
@@ -1,12 +1,12 @@
 diff --git a/constructor/header.sh b/constructor/header.sh
-index 7669ead..bcaecc8 100644
+index 129d3da..1d4d33c 100644
 --- a/constructor/header.sh
 +++ b/constructor/header.sh
-@@ -198,6 +198,21 @@ then
+@@ -249,6 +249,21 @@ then
  #endif
  
  #if aarch64
-+    if [[ -f /proc/device-tree/model && -n "$(cat /proc/device-tree/model | grep Raspberry)" ]]; then
++    if [ -f /proc/device-tree/model && -n "$(cat /proc/device-tree/model | grep Raspberry)" ]; then
 +        printf "WARNING:\\n"
 +        printf "    Your system appears to be a RaspberryPi.\\n"
 +        printf "    Anaconda packages may not be compatible with this system.\\n"


### PR DESCRIPTION
constructor 3.9.0

**Destination channel:** defaults

### Links

- [PKG-5501](https://anaconda.atlassian.net/browse/PKG-5501) 
- [Upstream repository](https://github.com/conda/constructor)
- [Upstream changelog/diff](https://github.com/conda/constructor/blob/main/CHANGELOG.md#2024-08-09---392)

### Explanation of changes:

- Update constructor to v3.9.2
- Make RaspberryPi patch POSIX compliant

[PKG-5501]: https://anaconda.atlassian.net/browse/PKG-5501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ