### PR TITLE
Update constructor to v3.9.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
-    sha256: 0ea4f6d563a53ebb03475dc6d2d88d3ab01be4e9d291fd276c79315aa92e5114
+    sha256: c88640ca1dcb93784cf754a16c53a098633808653aa52965c909a967b84815b9
     patches:                        # [aarch64]
       - raspberry-pi-warning.patch  # [aarch64]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.9.2" %}
+{% set version = "3.9.3" %}
 
 package:
   name: constructor

--- a/recipe/raspberry-pi-warning.patch
+++ b/recipe/raspberry-pi-warning.patch
@@ -1,12 +1,12 @@
 diff --git a/constructor/header.sh b/constructor/header.sh
-index 129d3da..1d4d33c 100644
+index f91e49a..4850e76 100644
 --- a/constructor/header.sh
 +++ b/constructor/header.sh
-@@ -249,6 +249,21 @@ then
+@@ -260,6 +260,21 @@ then
  #endif
  
  #if aarch64
-+    if [ -f /proc/device-tree/model && -n "$(cat /proc/device-tree/model | grep Raspberry)" ]; then
++    if [ -f /proc/device-tree/model ] && [ -n "$(cat /proc/device-tree/model | grep Raspberry)" ]; then
 +        printf "WARNING:\\n"
 +        printf "    Your system appears to be a RaspberryPi.\\n"
 +        printf "    Anaconda packages may not be compatible with this system.\\n"


### PR DESCRIPTION
constructor 3.9.3

**Destination channel:** defaults

### Links

- [INST-480](https://anaconda.atlassian.net/jira/software/projects/INST/issues/INST-480) 
- [Upstream repository](https://github.com/conda/constructor)
- [Upstream changelog/diff](https://github.com/conda/constructor/blob/main/CHANGELOG.md#2024-08-15---393)

### Explanation of changes:

- The RaspberryPi patch was incorrect and I noticed that `constructor` has not been updated to the latest version. So, I went a head and bumped it at the same time.

[INST-480]: https://anaconda.atlassian.net/browse/INST-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ