### PR TITLE
Update to v3.11.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.11.0" %}
+{% set version = "3.11.1" %}
 
 package:
   name: constructor
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
-    sha256: d25b07c4e543053b07d7ccdfbac3e5cd93c52dec908344e3a828ed010c23c7c6
+    sha256: bf35e45f7bd308079f4495e6d0905242fea1fb24fbffcfc07752b30d7a2ba3eb
     patches:                        # [aarch64]
       - raspberry-pi-warning.patch  # [aarch64]
 
@@ -32,8 +32,6 @@ requirements:
     - conda-standalone
     - pillow >=3.1     # [win or osx]
     - nsis >=3.08      # [win]
-    # Even though this is not listed as a requirement,
-    # building an installer will not work without it
     - jinja2
   run_constrained:     # [unix]
     - nsis >=3.08      # [unix]


### PR DESCRIPTION
constructor 3.11.1

**Destination channel:** defaults

### Links

- [{ticket_number}]() 
- [Upstream repository](https://github.com/conda/constructor)
- [Upstream changelog/diff](https://github.com/conda/constructor/blob/main/CHANGELOG.md#2025-01-14---3111)