### PR TITLE
Update to v3.11.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.11.1" %}
+{% set version = "3.11.2" %}
 
 package:
   name: constructor
@@ -6,12 +6,12 @@ package:
 
 source:
   - url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
-    sha256: bf35e45f7bd308079f4495e6d0905242fea1fb24fbffcfc07752b30d7a2ba3eb
+    sha256: fc499e251314a4752fa92bbea5ea422e81c505db056d268ed5f1148670cdc7d9
     patches:                        # [aarch64]
       - raspberry-pi-warning.patch  # [aarch64]
 
 build:
-  number: 1
+  number: 0
   script_env:
     - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation


### PR DESCRIPTION
constructor 3.11.2

**Destination channel:** defaults

### Links

- [PKG-7332](https://anaconda.atlassian.net/browse/PKG-7332) 
- [Upstream repository](https://github.com/conda/constructor)
- [Upstream changelog/diff](https://github.com/conda/constructor/blob/3.11.2/CHANGELOG.md#2025-03-06---3112)

[PKG-7332]: https://anaconda.atlassian.net/browse/PKG-7332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ