### PR TITLE
Update to v3.15.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.15.1" %}
+{% set version = "3.15.2" %}
 
 package:
   name: constructor
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
-    sha256: e9c37e392443bdc85ea9ff5af18a2ca57229e01fe5104247c6c1e70f47746994
+    sha256: 9bebf0c1cb5544c5255034a14b8fba1c5f883c7d3ecb1ea900dad6d699859213
     patches:                        # [aarch64]
       - raspberry-pi-warning.patch  # [aarch64]
 
@@ -18,7 +18,7 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - constructor = constructor.main:main
-  skip: true  # [py<38]
+  skip: true  # [py<310]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
   run_constrained:     # [unix]
     - nsis >=3.08      # [unix]
     - conda-libmamba-solver !=24.11.0
-    - pydantic >=2.11,<2.12
+    - pydantic >=2.11
 test:
   source_files:
     - tests


### PR DESCRIPTION
constructor 3.15.2

**Destination channel:** defaults

### Links

- [PKG-13473](https://anaconda.atlassian.net/browse/PKG-13473)
- [Upstream repository](https://github.com/conda/constructor)
- [Upstream changelog/diff](https://github.com/conda/constructor/blob/main/CHANGELOG.md#2026-04-07---3152)

### Explanation of changes:

- Removed run constraint of `pydantic`. The pin was only needed to get consistent schema JSON outputs for upstream tests, and `pydantic 2.11.*` is not available for Python 3.14.

[PKG-13473]: https://anaconda.atlassian.net/browse/PKG-13473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ