### PR TITLE
Update constructor to v3.16.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ requirements:
     - nsis >=3.08      # [win]
     - jinja2
     - jsonschema >=4
+    - briefcase >=0.3.26  # [win]
+    - tomli-w >=1.2.0     # [win]
   run_constrained:     # [unix]
     - nsis >=3.08      # [unix]
     - conda-libmamba-solver !=24.11.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ test:
   requires:
     - pip
     - pytest
+    - pytest-mock
     - conda-libmamba-solver
     - nsis =*=*log*  # [win]
     - pywin32        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.15.3" %}
+{% set version = "3.16.1" %}
 
 package:
   name: constructor
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
-    sha256: 079ab23d3c636b408d88a87afe1c858b1a0c589b48729c305e051f118d490c7b
+    sha256: 5eeed6a828ccff7bec2b8d30fecb8f9b2425c1e7fb9643c4af2b665d5a80ff89
     patches:                        # [aarch64]
       - raspberry-pi-warning.patch  # [aarch64]
 


### PR DESCRIPTION
constructor 3.16.1

**Destination channel:** defaults

### Links

- [PKG-15847](https://anaconda.atlassian.net/browse/PKG-15847) 
- [Upstream repository](https://github.com/conda/constructor/)
- [Upstream changelog/diff](https://github.com/conda/constructor/blob/main/CHANGELOG.md#2026-06-22---3161)


[PKG-15847]: https://anaconda.atlassian.net/browse/PKG-15847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ