### PR TITLE
Update to 3.16.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,9 +24,8 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-- setuptools >=70.1
-- setuptools-scm >=6.2
+    - setuptools >=70.1
+    - setuptools-scm >=6.2
     - wheel
   run:
     - conda >=4.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.16.1" %}
+{% set version = "3.16.2" %}
 
 package:
   name: constructor
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
-    sha256: 5eeed6a828ccff7bec2b8d30fecb8f9b2425c1e7fb9643c4af2b665d5a80ff89
+    sha256: 6fdb5147e1bfcc4fd91324de5bb64cadf9033386effc000a43bd4117e912c9e0
     patches:                        # [aarch64]
       - raspberry-pi-warning.patch  # [aarch64]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,10 @@ requirements:
 test:
   source_files:
     - tests
+    # No such file or directory: '../examples/miniforge/construct.yaml'
+    - examples/miniforge
+    # No such file or directory: '../examples/miniforge-mamba2/construct.yaml'
+    - examples/miniforge-mamba2/
     # Include when running examples
     # - scripts
     # - examples

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,13 +25,14 @@ requirements:
     - python
     - pip
     - setuptools
-    - setuptools-scm
+- setuptools >=70.1
+- setuptools-scm >=6.2
     - wheel
   run:
     - conda >=4.6
     - python
     - ruamel.yaml >=0.11.14,<0.19
-    - conda-standalone >=24.1.2
+    - conda-standalone >=24.11.0
     - pillow >=3.1     # [win or osx]
     - nsis >=3.08      # [win]
     - jinja2


### PR DESCRIPTION
`constructor 3.16.2`

**Destination channel:** defaults

### Links

- [PKG-16238](https://anaconda.atlassian.net/browse/PKG-16238) 
- [Upstream repository](https://github.com/conda/constructor)
- [Upstream changelog/diff](https://github.com/conda/constructor/blob/main/CHANGELOG.md#2026-07-07---3162)



[PKG-16238]: https://anaconda.atlassian.net/browse/PKG-16238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ