### PR TITLE
Prepare 3.16.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.16.2" %}
+{% set version = "3.16.3" %}
 
 package:
   name: constructor
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
-    sha256: 6fdb5147e1bfcc4fd91324de5bb64cadf9033386effc000a43bd4117e912c9e0
+    sha256: 3e219ad324ebfc0ff80648beb19d490799df609ab1cb9bfe11e2b91fa79dcb52
     patches:                        # [aarch64]
       - raspberry-pi-warning.patch  # [aarch64]
 


### PR DESCRIPTION
`constructor 3.16.3`

**Destination channel:** defaults

### Links

- [PKG-16876](https://anaconda.atlassian.net/browse/PKG-16876) 
- [Upstream repository](https://github.com/conda/constructor)
- [Upstream changelog/diff](https://github.com/conda/constructor/blob/main/CHANGELOG.md#2026-07-28---3163)


[PKG-16876]: https://anaconda.atlassian.net/browse/PKG-16876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ